### PR TITLE
異常系の改善

### DIFF
--- a/Kanikama/Assets/Kanikama/Scripts/Editor/BakeSceneController.cs
+++ b/Kanikama/Assets/Kanikama/Scripts/Editor/BakeSceneController.cs
@@ -70,7 +70,7 @@ namespace Kanikama.Editor
                 {
                     var sharedMaterials = renderer.sharedMaterials;
 
-                    if (sharedMaterials.Any(x => x.IsKeywordEnabled(KanikamaEmissiveMaterial.ShaderKeywordEmission)))
+                    if (sharedMaterials.Any(x => !(x is null) && x.IsKeywordEnabled(KanikamaEmissiveMaterial.ShaderKeywordEmission)))
                     {
                         nonKanikamaMaterialMaps[renderer.gameObject] = sharedMaterials;
                         renderer.sharedMaterials = Enumerable.Repeat(dummyMaterial, sharedMaterials.Length).ToArray();

--- a/Kanikama/Assets/Kanikama/Scripts/Editor/BakeWindow.cs
+++ b/Kanikama/Assets/Kanikama/Scripts/Editor/BakeWindow.cs
@@ -276,7 +276,7 @@ namespace Kanikama.Editor
             }
             catch (TaskCanceledException)
             {
-                Debug.Log("キャンセルされました");
+                Debug.Log("[Kanikama] Bake canceled");
             }
             finally
             {


### PR DESCRIPTION
* `catch` した例外を `throw e;` で投げ直すとスタックトレースが消滅してようわからんくなるので `throw;` で投げ直すようにした
  - 参考: https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2200

* よくわからんが `sharedMaterials` に `null` が入ってることがよくあるのでそれをうまく無視するようにした

* Lightmapper のベイクの開始に失敗すると致命的なのにどんどん進んでいってしまうので止まるようにした

* デバッグログにヘッダ `[Kanikama]` を追加して誰の吐いたログなのかわかりやすくした．ついでに文面を少し修正