### PR TITLE
Fix Directional Specular.

### DIFF
--- a/Kanikama/Assets/Kanikama/Scripts/Baking/Baker.cs
+++ b/Kanikama/Assets/Kanikama/Scripts/Baking/Baker.cs
@@ -206,7 +206,7 @@ namespace Kanikama.Baking
                 .Where(x => ValidateTexturePath(x))
                 .Select(x => AssetDatabase.LoadAssetAtPath<Texture2D>(x.Path))
                 .ToList();
-            var dirTexArr = Texture2DArrayGenerator.Generate(dirTextures);
+            var dirTexArr = Texture2DArrayGenerator.Generate(dirTextures, true);
             var dirTexArrPath = Path.Combine(kanikamaPath.ExportDirPath, string.Format(KanikamaPath.DirTexArrFormat, mapIndex));
             KanikamaEditorUtility.CreateOrReplaceAsset(ref dirTexArr, dirTexArrPath);
             Debug.Log($"[Kanikama] Created {dirTexArrPath}");

--- a/Kanikama/Assets/Kanikama/Scripts/Editor/StandardShaderGUI.cs
+++ b/Kanikama/Assets/Kanikama/Scripts/Editor/StandardShaderGUI.cs
@@ -31,13 +31,6 @@ namespace Kanikama.Editor
             AlbedoAlpha,
         }
 
-        public enum KanikamaMode
-        {
-            Single,
-            Array,
-            Directional,
-        }
-
         private static class Styles
         {
             public static GUIContent uvSetLabel = EditorGUIUtility.TrTextContent("UV Set");
@@ -68,7 +61,6 @@ namespace Kanikama.Editor
 
             public static string kanikamaText = "Kanikama";
             public static GUIContent kanikamaModeText = EditorGUIUtility.TrTextContent("Kanikama Mode", "Kanikama Mode");
-            public static GUIContent kanikamaSpecularText = EditorGUIUtility.TrTextContent("Directional Specular", "Directional Specular");
         }
 
         MaterialProperty blendMode = null;
@@ -99,7 +91,6 @@ namespace Kanikama.Editor
         MaterialProperty uvSetSecondary = null;
 
         MaterialProperty kanikamaMode = null;
-        MaterialProperty kanikamaSpecular = null;
 
         MaterialEditor m_MaterialEditor;
         WorkflowMode m_WorkflowMode = WorkflowMode.Specular;
@@ -142,7 +133,6 @@ namespace Kanikama.Editor
             uvSetSecondary = FindProperty("_UVSec", props);
 
             kanikamaMode = FindProperty("_Kanikama_Mode", props);
-            kanikamaSpecular = FindProperty("_Kanikama_Specular", props);
         }
 
         public override void OnGUI(MaterialEditor materialEditor, MaterialProperty[] props)
@@ -481,7 +471,6 @@ namespace Kanikama.Editor
         void DoKanikamaArea()
         {
             m_MaterialEditor.ShaderProperty(kanikamaMode, Styles.kanikamaModeText);
-            m_MaterialEditor.ShaderProperty(kanikamaSpecular, Styles.kanikamaSpecularText);
         }
     }
 } // namespace Kanikama.Editor

--- a/Kanikama/Assets/Kanikama/Shaders/CGIncludes/KanikamaComposite.hlsl
+++ b/Kanikama/Assets/Kanikama/Shaders/CGIncludes/KanikamaComposite.hlsl
@@ -32,7 +32,7 @@ inline half3 KanikamaSampleLightmapArray(float2 lightmapUV)
     return col;
 }
 
-#if defined(_KANIKAMA_MODE_DIRECTIONAL)
+#if defined(_KANIKAMA_MODE_DIRECTIONAL) || defined(_KANIKAMA_MODE_DIRECTIONAL_SPECULAR)
 UNITY_DECLARE_TEX2DARRAY_NOSAMPLER(knkm_LightmapIndArray);
 
 inline half3 KanikamaSampleDirectionalLightmapArray(float2 lightmapUV, float3 normalWorld)

--- a/Kanikama/Assets/Kanikama/Shaders/CGIncludes/KanikamaComposite.hlsl
+++ b/Kanikama/Assets/Kanikama/Shaders/CGIncludes/KanikamaComposite.hlsl
@@ -33,7 +33,7 @@ inline half3 KanikamaSampleLightmapArray(float2 lightmapUV)
 }
 
 #if defined(_KANIKAMA_MODE_DIRECTIONAL)
-UNITY_DECLARE_TEX2DARRAY(knkm_LightmapIndArray);
+UNITY_DECLARE_TEX2DARRAY_NOSAMPLER(knkm_LightmapIndArray);
 
 inline half3 KanikamaSampleDirectionalLightmapArray(float2 lightmapUV, float3 normalWorld)
 {
@@ -41,7 +41,7 @@ inline half3 KanikamaSampleDirectionalLightmapArray(float2 lightmapUV, float3 no
     for (int i = 0; i < knkm_Count; i++)
     {
         half3 bakedColor = DecodeLightmap(UNITY_SAMPLE_TEX2DARRAY(knkm_LightmapArray, float3(lightmapUV.x, lightmapUV.y, i))) * knkm_Colors[i];
-        fixed4 bakedDirTex = UNITY_SAMPLE_TEX2DARRAY(knkm_LightmapIndArray, float3(lightmapUV.x, lightmapUV.y, i));
+        fixed4 bakedDirTex = UNITY_SAMPLE_TEX2DARRAY_SAMPLER(knkm_LightmapIndArray, knkm_LightmapArray, float3(lightmapUV.x, lightmapUV.y, i));
         col += DecodeDirectionalLightmap(bakedColor, bakedDirTex, normalWorld);
     }
 

--- a/Kanikama/Assets/Kanikama/Shaders/Standard/KanikamaGlobalIllumination.hlsl
+++ b/Kanikama/Assets/Kanikama/Shaders/Standard/KanikamaGlobalIllumination.hlsl
@@ -68,7 +68,7 @@
             o_gi.indirect.diffuse += KanikamaSampleLightmap(data.lightmapUV.xy);
         #elif defined(_KANIKAMA_MODE_ARRAY)
             o_gi.indirect.diffuse += KanikamaSampleLightmapArray(data.lightmapUV.xy);
-        #elif defined(_KANIKAMA_MODE_DIRECTIONAL) && !defined(_KANIKAMA_SPECULAR)
+        #elif defined(_KANIKAMA_MODE_DIRECTIONAL)
             o_gi.indirect.diffuse += KanikamaSampleDirectionalLightmapArray(data.lightmapUV.xy, normalWorld);
         #endif
 
@@ -77,7 +77,7 @@
     }
 
 
-#if defined(_KANIKAMA_MODE_DIRECTIONAL) && defined(_KANIKAMA_SPECULAR)
+#if defined(_KANIKAMA_MODE_DIRECTIONAL_SPECULAR)
     // Directional lightmap specular based on BakeryDirectionalLightmapSpecular in Bakery.cginc by Mr F
     // https://geom.io/bakery/wiki/
     inline void KanikamaDirectionalLightmapSpecular(float2 lightmapUV, half3 normalWorld, half3 viewDir, half roughness, half occulsion, out half3 diffuse, out half3 specular)
@@ -102,7 +102,7 @@
         UnityGI o_gi = KanikamaGI_Base(data, occlusion, normalWorld);
         o_gi.indirect.specular = UnityGI_IndirectSpecular(data, occlusion, glossIn);
 
-#if defined(_KANIKAMA_MODE_DIRECTIONAL) && defined(_KANIKAMA_SPECULAR)
+#if defined(_KANIKAMA_MODE_DIRECTIONAL_SPECULAR)
         half roughness = PerceptualRoughnessToRoughness(glossIn.roughness);
         half3 diffuse;
         half3 specular;

--- a/Kanikama/Assets/Kanikama/Shaders/Standard/KanikamaGlobalIllumination.hlsl
+++ b/Kanikama/Assets/Kanikama/Shaders/Standard/KanikamaGlobalIllumination.hlsl
@@ -77,15 +77,39 @@
     }
 
 
-    inline UnityGI KanikamaGlobalIllumination(UnityGIInput data, half occlusion, half3 normalWorld)
+#if defined(_KANIKAMA_MODE_DIRECTIONAL) && defined(_KANIKAMA_SPECULAR)
+    // Directional lightmap specular based on BakeryDirectionalLightmapSpecular in Bakery.cginc by Mr F
+    // https://geom.io/bakery/wiki/
+    inline void KanikamaDirectionalLightmapSpecular(float2 lightmapUV, half3 normalWorld, half3 viewDir, half roughness, half occulsion, out half3 diffuse, out half3 specular)
     {
-        return KanikamaGI_Base(data, occlusion, normalWorld);
+        for (int i = 0; i < knkm_Count; i++)
+        {
+            half3 bakedColor = DecodeLightmap(UNITY_SAMPLE_TEX2DARRAY(knkm_LightmapArray, float3(lightmapUV.x, lightmapUV.y, i))) * knkm_Colors[i];
+            half4 dirTex = UNITY_SAMPLE_TEX2DARRAY_SAMPLER(knkm_LightmapIndArray, knkm_LightmapArray, float3(lightmapUV.x, lightmapUV.y, i));
+            half3 dominantDir = dirTex.xyz - 0.5;
+            half3 halfDir = Unity_SafeNormalize(normalize(dominantDir) + viewDir);
+            half nh = saturate(dot(normalWorld, halfDir));
+            half spec = GGXTerm(nh, roughness);
+            half halfLambert = dot(normalWorld, dominantDir) + 0.5;
+            half3 diff = bakedColor * halfLambert / max(1e-4h, dirTex.w);
+            diffuse += diff * occulsion;
+            specular += spec * bakedColor * occulsion;
+        }
     }
-
+#endif
     inline UnityGI KanikamaGlobalIllumination(UnityGIInput data, half occlusion, half3 normalWorld, Unity_GlossyEnvironmentData glossIn)
     {
         UnityGI o_gi = KanikamaGI_Base(data, occlusion, normalWorld);
         o_gi.indirect.specular = UnityGI_IndirectSpecular(data, occlusion, glossIn);
+
+#if defined(_KANIKAMA_MODE_DIRECTIONAL) && defined(_KANIKAMA_SPECULAR)
+        half roughness = PerceptualRoughnessToRoughness(glossIn.roughness);
+        half3 diffuse;
+        half3 specular;
+        KanikamaDirectionalLightmapSpecular(data.lightmapUV.xy, normalWorld, data.worldViewDir, roughness, occlusion, /* out */ diffuse, /* out */specular);
+        o_gi.indirect.diffuse += diffuse;
+        o_gi.indirect.specular += specular;
+#endif
         return o_gi;
     }
 

--- a/Kanikama/Assets/Kanikama/Shaders/Standard/Kanikama_Standard.shader
+++ b/Kanikama/Assets/Kanikama/Shaders/Standard/Kanikama_Standard.shader
@@ -5,8 +5,7 @@ Shader "Kanikama/Standard"
 {
     Properties
     {
-        [KeywordEnum(None, Single, Array, Directional)] _Kanikama_Mode("Kanikama Mode", Float) = 0
-        [Toggle(_KANIKAMA_SPECULAR)] _Kanikama_Specular("Directional Specular", Float) = 0
+        [KeywordEnum(None, Single, Array, Directional, Directional_Specular)] _Kanikama_Mode("Kanikama Mode", Float) = 0
         [Space]
 
         _Color("Color", Color) = (1,1,1,1)
@@ -87,8 +86,7 @@ Shader "Kanikama/Standard"
             #pragma shader_feature _ _GLOSSYREFLECTIONS_OFF
             #pragma shader_feature _PARALLAXMAP
 
-            #pragma shader_feature_local_fragment _ _KANIKAMA_MODE_SINGLE _KANIKAMA_MODE_ARRAY _KANIKAMA_MODE_DIRECTIONAL
-            #pragma shader_feature_local_fragment _KANIKAMA_SPECULAR
+            #pragma shader_feature_local_fragment _ _KANIKAMA_MODE_SINGLE _KANIKAMA_MODE_ARRAY _KANIKAMA_MODE_DIRECTIONAL _KANIKAMA_MODE_DIRECTIONAL_SPECULAR
 
             #pragma multi_compile_fwdbase
             #pragma multi_compile_fog

--- a/Kanikama/Assets/KanikamaSample/Materials/KanikamaStandard_Directional.mat
+++ b/Kanikama/Assets/KanikamaSample/Materials/KanikamaStandard_Directional.mat
@@ -9,7 +9,8 @@ Material:
   m_PrefabAsset: {fileID: 0}
   m_Name: KanikamaStandard_Directional
   m_Shader: {fileID: 4800000, guid: 613fb6b242a059c40be003a3f0ec5826, type: 3}
-  m_ShaderKeywords: _KANIKAMA_MODE_DIRECTIONAL _KANIKAMA_SPECULAR _NORMALMAP _PARALLAXMAP
+  m_ShaderKeywords: _KANIKAMA_MODE_DIRECTIONAL_SPECULAR _KANIKAMA_SPECULAR _NORMALMAP
+    _PARALLAXMAP
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
@@ -65,13 +66,13 @@ Material:
     - _DetailNormalMapScale: 1
     - _DstBlend: 0
     - _GlossMapScale: 1
-    - _Glossiness: 0.52
+    - _Glossiness: 0.811
     - _GlossyReflections: 1
     - _KanikamaDirectional: 0
     - _KanikamaMode: 1
-    - _Kanikama_Mode: 3
+    - _Kanikama_Mode: 4
     - _Kanikama_Specular: 1
-    - _Metallic: 0.443
+    - _Metallic: 0
     - _Mode: 0
     - _OcclusionStrength: 1
     - _Parallax: 0.0483


### PR DESCRIPTION
close https://github.com/shivaduke28/kanikama/issues/89

- fix color space of directional map arrays.
- remove `KANIKAMA_SPECULAR` keyword and add `KANIKAMA_DIRECTIONAL_SPECULAR` to Kanikama Mode enum.