### PR TITLE
Pack 3 light maps into one by Luminance

### DIFF
--- a/Kanikama/Assets/Kanikama/Scripts/Baking/BakeRequest.cs
+++ b/Kanikama/Assets/Kanikama/Scripts/Baking/BakeRequest.cs
@@ -5,26 +5,26 @@ namespace Kanikama.Baking
 {
     public class BakeRequest
     {
-        public bool isBakeAll = true;
+        public bool IsBakeAll = true;
 
-        public List<bool> lightSourceFlags;
-        public List<bool> lightSourceGroupFlags;
+        public readonly List<bool> LightSourceFlags;
+        public readonly List<bool> LightSourceGroupFlags;
 
-        public bool isBakeAmbient = true;
-        public bool isGenerateAssets = true;
-        public bool isBakeWithouKanikama = true;
-        public bool isDirectionalMode = false;
-        public bool createRenderTexture;
-        public bool createCustomRenderTexture;
+        public bool IsGenerateAssets = true;
+        public bool IsBakeNonKanikama = true;
+        public bool IsDirectionalMode = false;
+        public bool IsPackTextures = false;
+        public bool IsCreateRenderTexture;
+        public bool IsCreateCustomRenderTexture;
 
-        public bool IsBakeLightSource(int index) => isBakeAll || lightSourceFlags[index];
-        public bool IsBakeLightSourceGroup(int index) => isBakeAll || lightSourceGroupFlags[index];
-        public bool IsBakeWithouKanikama() => isBakeAll || isBakeWithouKanikama;
+        public bool IsBakeLightSource(int index) => IsBakeAll || LightSourceFlags[index];
+        public bool IsBakeLightSourceGroup(int index) => IsBakeAll || LightSourceGroupFlags[index];
+        public bool IsBakeWithoutKanikama() => IsBakeAll || IsBakeNonKanikama;
 
         public BakeRequest(int sourceCount, int groupCount)
         {
-            lightSourceFlags = Enumerable.Repeat(true, sourceCount).ToList();
-            lightSourceGroupFlags = Enumerable.Repeat(true, groupCount).ToList();
+            LightSourceFlags = Enumerable.Repeat(true, sourceCount).ToList();
+            LightSourceGroupFlags = Enumerable.Repeat(true, groupCount).ToList();
         }
     }
 }

--- a/Kanikama/Assets/Kanikama/Scripts/Baking/BakedAsset.cs
+++ b/Kanikama/Assets/Kanikama/Scripts/Baking/BakedAsset.cs
@@ -13,6 +13,7 @@ namespace Kanikama.Baking
         public List<Material> customRenderTextureMaterials = new List<Material>();
         public List<RenderTexture> renderTextures = new List<RenderTexture>();
         public List<Material> renderTextureMaterials = new List<Material>();
+        public int sliceCount;
 
         public void RemoveNullAssets()
         {

--- a/Kanikama/Assets/Kanikama/Scripts/Baking/Texture2DArrayGenerator.cs
+++ b/Kanikama/Assets/Kanikama/Scripts/Baking/Texture2DArrayGenerator.cs
@@ -11,6 +11,15 @@ namespace Kanikama.Baking
         public List<Texture2D> textures = new List<Texture2D>();
         public string fileName = "texture2d_array";
 
+        class ShaderProperties
+        {
+            public static readonly int Tex0 = Shader.PropertyToID("_Tex0");
+            public static readonly int Tex1 = Shader.PropertyToID("_Tex1");
+
+            public static readonly int Tex2 = Shader.PropertyToID("_Tex2");
+            public static readonly int Tex3 = Shader.PropertyToID("_Tex3");
+        }
+
         [ContextMenu("Generate")]
         public Texture2DArray Generate()
         {
@@ -30,6 +39,80 @@ namespace Kanikama.Baking
             var dir = Path.GetDirectoryName(path);
             KanikamaEditorUtility.CreateOrReplaceAsset(ref texArray, Path.Combine(dir, $"{fileName}.asset"));
             AssetDatabase.Refresh();
+            return texArray;
+        }
+
+        public static Texture2DArray PackBC6H(List<Texture2D> textures, bool isLinear = false)
+        {
+            var count = textures.Count;
+            if (count == 0)
+            {
+                Debug.LogError("The size of Textures is zero.");
+                return null;
+            }
+
+            // Pack 3 textures into RGB via Luminance
+            // NOTE: alpha channel is not available for BC6H
+            var sliceCount = Mathf.FloorToInt(count / 3f) + 1;
+
+            var map = textures[0];
+            var texArray = new Texture2DArray(map.width, map.height, sliceCount, map.format, mipChain: true, linear: false)
+            {
+                anisoLevel = map.anisoLevel,
+                wrapMode = map.wrapMode,
+                filterMode = map.filterMode,
+            };
+
+            var shader = Shader.Find("Kanikama/Pack");
+            var mat = new Material(shader);
+
+            var rtDescriptor = new RenderTextureDescriptor(map.width, map.height)
+            {
+                dimension = UnityEngine.Rendering.TextureDimension.Tex2D,
+                colorFormat = RenderTextureFormat.ARGBHalf,
+                useMipMap = true,
+                depthBufferBits = 0,
+                useDynamicScale = false,
+                msaaSamples = 1,
+                volumeDepth = 1
+            };
+
+            var rt = RenderTexture.GetTemporary(rtDescriptor);
+
+            var active = RenderTexture.active;
+            var param = new TextureGenerator.Parameter
+            {
+                Width = map.width,
+                Height = map.height,
+                Format = TextureFormat.RGBAHalf, // map.format should be BC6H
+                Linear = false,
+                MipChain = true,
+            };
+
+            for (var i = 0; i < sliceCount; i++)
+            {
+                var j = i * 3;
+                mat.SetTexture(ShaderProperties.Tex0, GetTexture(j));
+                mat.SetTexture(ShaderProperties.Tex1, GetTexture(j + 1));
+                mat.SetTexture(ShaderProperties.Tex2, GetTexture(j + 2));
+
+                var tex = TextureGenerator.GenerateTexture(param);
+                RenderTexture.active = rt;
+                Graphics.Blit(null, rt, mat);
+                tex.ReadPixels(new Rect(0, 0, rt.width, rt.height), 0, 0, true);
+                EditorUtility.CompressTexture(tex, TextureFormat.BC6H, TextureCompressionQuality.Best);
+                Graphics.CopyTexture(tex, 0, texArray, i);
+                DestroyImmediate(tex);
+            }
+
+            Texture GetTexture(int index)
+            {
+                return index < count ? textures[index] : Texture2D.blackTexture;
+            }
+
+            RenderTexture.active = active;
+            RenderTexture.ReleaseTemporary(rt);
+            DestroyImmediate(mat);
             return texArray;
         }
 
@@ -53,6 +136,7 @@ namespace Kanikama.Baking
                 var lightmap = textures[i];
                 Graphics.CopyTexture(lightmap, 0, texArray, i);
             }
+
             return texArray;
         }
     }

--- a/Kanikama/Assets/Kanikama/Scripts/Baking/TextureGenerator.cs
+++ b/Kanikama/Assets/Kanikama/Scripts/Baking/TextureGenerator.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
+﻿using System;
 using UnityEngine;
 using UnityEditor;
 using System.IO;
@@ -8,44 +7,67 @@ namespace Kanikama.Baking
 {
     public class TextureGenerator
     {
-        public static Texture2D GenerateTexture(string dirPath, string name, Parameter parameter)
+        public static void SaveTexture2D(Texture2D texture, string dirPath, string name, ImportParameter parameter)
         {
-            var texture = GenerateTexture(parameter);
-            var ext = parameter.extension == TextureExtension.Png ? "png" : "exr";
+            string ext;
+            byte[] bytes;
+            if (parameter.Extension == TextureExtension.Png)
+            {
+                ext = "png";
+                bytes = texture.EncodeToPNG();
+            }
+            else
+            {
+                ext = "exr";
+                bytes = texture.EncodeToEXR();
+            }
+
             var path = Path.Combine(dirPath, $"{name}.{ext}");
-            var bytes = texture.EncodeToEXR();
             File.WriteAllBytes(path, bytes);
-            AssetDatabase.Refresh();
-            var textureImporter = AssetImporter.GetAtPath(path) as TextureImporter;
-            textureImporter.isReadable = parameter.isReadable;
-            textureImporter.textureCompression = TextureImporterCompression.Uncompressed;
+            AssetDatabase.ImportAsset(path);
+            var textureImporter = (TextureImporter) AssetImporter.GetAtPath(path);
+            textureImporter.isReadable = parameter.IsReadable;
+            textureImporter.textureCompression = parameter.Compression;
             textureImporter.SaveAndReimport();
-            Debug.Log($"{path} has been generated.");
-            return texture;
+            if (parameter.Compression != TextureImporterCompression.Uncompressed)
+            {
+                EditorUtility.CompressTexture(texture, parameter.CompressedFormat, parameter.CompressionQuality);
+            }
+
+            Debug.Log($"{path} has been saved.");
         }
 
         public static Texture2D GenerateTexture(Parameter parameter)
         {
-            return new Texture2D(parameter.width, parameter.height, parameter.format, parameter.mipChain, parameter.linear);
+            return new Texture2D(parameter.Width, parameter.Height, parameter.Format, parameter.MipChain, parameter.Linear);
         }
 
         public static RenderTexture GenerateRenderTexture(string dirPath, string name, RenderTextureDescriptor parameter)
         {
             var rt = new RenderTexture(parameter);
             var path = Path.Combine(dirPath, $"{name}.renderTexture");
-            KanikamaEditorUtility.CreateOrReplaceAsset<RenderTexture>(ref rt, path);
+            KanikamaEditorUtility.CreateOrReplaceAsset(ref rt, path);
             return rt;
         }
 
+        [Serializable]
         public class Parameter
         {
-            public int width = 256;
-            public int height = 256;
-            public TextureFormat format = TextureFormat.RGBAHalf;
-            public bool mipChain = true;
-            public bool linear = true;
-            public TextureExtension extension = TextureExtension.Exr;
-            public bool isReadable = true;
+            public int Width = 256;
+            public int Height = 256;
+            public TextureFormat Format = TextureFormat.RGBAHalf;
+            public bool MipChain = true;
+            public bool Linear = true;
+        }
+
+        [Serializable]
+        public class ImportParameter
+        {
+            public TextureExtension Extension = TextureExtension.Exr;
+            public bool IsReadable = true;
+            public TextureImporterCompression Compression = TextureImporterCompression.Uncompressed;
+            public TextureFormat CompressedFormat = TextureFormat.BC6H;
+            public TextureCompressionQuality CompressionQuality = TextureCompressionQuality.Best;
         }
 
         public enum TextureExtension

--- a/Kanikama/Assets/Kanikama/Scripts/Editor/BakeWindow.cs
+++ b/Kanikama/Assets/Kanikama/Scripts/Editor/BakeWindow.cs
@@ -131,11 +131,12 @@ namespace Kanikama.Editor
             GUILayout.Label("Scene", EditorStyles.boldLabel);
             using (new EditorGUI.DisabledGroupScope(true))
             {
-                sceneAsset = (SceneAsset)EditorGUILayout.ObjectField("Scene", sceneAsset, typeof(SceneAsset), false);
+                sceneAsset = (SceneAsset) EditorGUILayout.ObjectField("Scene", sceneAsset, typeof(SceneAsset), false);
             }
-            sceneDescriptor = (KanikamaSceneDescriptor)EditorGUILayout.ObjectField("Scene Descriptor",
+
+            sceneDescriptor = (KanikamaSceneDescriptor) EditorGUILayout.ObjectField("Scene Descriptor",
                 sceneDescriptor, typeof(KanikamaSceneDescriptor), true);
-            settings = (KanikamaSettings)EditorGUILayout.ObjectField("Settings", settings, typeof(KanikamaSettings), false);
+            settings = (KanikamaSettings) EditorGUILayout.ObjectField("Settings", settings, typeof(KanikamaSettings), false);
 
             if (GUILayout.Button("Load Active Scene"))
             {
@@ -167,13 +168,14 @@ namespace Kanikama.Editor
                         Stop();
                     }
                 }
+
                 return;
             }
 
             EditorGUI.BeginChangeCheck();
             if (IsBakeryIncluded())
             {
-                settings.lightmapperType = (LightmapperType)EditorGUILayout.EnumPopup("Lightmapper", settings.lightmapperType);
+                settings.lightmapperType = (LightmapperType) EditorGUILayout.EnumPopup("Lightmapper", settings.lightmapperType);
             }
             else
             {
@@ -183,6 +185,7 @@ namespace Kanikama.Editor
                     EditorGUILayout.EnumPopup("Lightmapper", settings.lightmapperType);
                 }
             }
+
             if (lightmapper == null || EditorGUI.EndChangeCheck())
             {
                 lightmapper = CreateLightmapper(settings.lightmapperType);
@@ -197,17 +200,18 @@ namespace Kanikama.Editor
             {
                 using (new EditorGUI.DisabledGroupScope(true))
                 {
-                    settings.directionalMode = false;
-                    settings.directionalMode = EditorGUILayout.Toggle("Directional Mode", settings.directionalMode);
+                    settings.directionalMode = EditorGUILayout.Toggle("Directional Mode", false);
                 }
             }
+
+            settings.packTextures = EditorGUILayout.Toggle("Pack Textures", settings.packTextures);
 
 
             EditorGUILayout.Space();
 
-            bakeRequest.isBakeAll = EditorGUILayout.Toggle("Bake All", bakeRequest.isBakeAll);
+            bakeRequest.IsBakeAll = EditorGUILayout.Toggle("Bake All", bakeRequest.IsBakeAll);
 
-            using (new EditorGUI.DisabledGroupScope(bakeRequest.isBakeAll))
+            using (new EditorGUI.DisabledGroupScope(bakeRequest.IsBakeAll))
             {
                 using (new EditorGUI.IndentLevelScope(EditorGUI.indentLevel++))
                 {
@@ -215,7 +219,7 @@ namespace Kanikama.Editor
                     EditorGUILayout.LabelField("Light Source");
                     using (new EditorGUI.IndentLevelScope(indentLevel))
                     {
-                        var sourceFlags = bakeRequest.lightSourceFlags;
+                        var sourceFlags = bakeRequest.LightSourceFlags;
                         var source = sceneDescriptor.GetLightSources();
                         var lightCount = Mathf.Min(sourceFlags.Count, source.Count);
                         for (var i = 0; i < lightCount; i++)
@@ -227,7 +231,7 @@ namespace Kanikama.Editor
                     EditorGUILayout.LabelField("Light Source Group");
                     using (new EditorGUI.IndentLevelScope(indentLevel))
                     {
-                        var groupFlags = bakeRequest.lightSourceGroupFlags;
+                        var groupFlags = bakeRequest.LightSourceGroupFlags;
                         var group = sceneDescriptor.GetLightSourceGroups();
                         var groupCount = Mathf.Min(groupFlags.Count, group.Count);
                         for (var i = 0; i < groupCount; i++)
@@ -236,8 +240,8 @@ namespace Kanikama.Editor
                         }
                     }
 
-                    bakeRequest.isBakeWithouKanikama = EditorGUILayout.Toggle("Non-Kanikama GI", bakeRequest.isBakeWithouKanikama);
-                    bakeRequest.isGenerateAssets = EditorGUILayout.Toggle("Create Assets", bakeRequest.isGenerateAssets);
+                    bakeRequest.IsBakeNonKanikama = EditorGUILayout.Toggle("Non-Kanikama GI", bakeRequest.IsBakeNonKanikama);
+                    bakeRequest.IsGenerateAssets = EditorGUILayout.Toggle("Create Assets", bakeRequest.IsGenerateAssets);
                 }
             }
         }
@@ -292,9 +296,10 @@ namespace Kanikama.Editor
 
         async void BakeAsync()
         {
-            bakeRequest.isDirectionalMode = settings.directionalMode;
-            bakeRequest.createRenderTexture = settings.createRenderTexture;
-            bakeRequest.createCustomRenderTexture = settings.createCustomRenderTexture;
+            bakeRequest.IsDirectionalMode = settings.directionalMode;
+            bakeRequest.IsCreateRenderTexture = settings.createRenderTexture;
+            bakeRequest.IsCreateCustomRenderTexture = settings.createCustomRenderTexture;
+            bakeRequest.IsPackTextures = settings.packTextures;
             tokenSource = new CancellationTokenSource();
             lightmapper = CreateLightmapper(settings.lightmapperType);
             var sceneManager = CreateSceneManager(settings.lightmapperType, sceneDescriptor);

--- a/Kanikama/Assets/Kanikama/Scripts/Editor/KanikamaSettings.cs
+++ b/Kanikama/Assets/Kanikama/Scripts/Editor/KanikamaSettings.cs
@@ -9,11 +9,12 @@ namespace Kanikama.Editor
     [CreateAssetMenu(menuName = "Kanikama/Settings", fileName = "KanikamaSettings")]
     public class KanikamaSettings : ScriptableObject
     {
-        [SerializeField] private SceneAsset sceneAsset;
+        [SerializeField] SceneAsset sceneAsset;
         public LightmapperType lightmapperType;
         public bool directionalMode;
         public bool createRenderTexture;
         public bool createCustomRenderTexture;
+        public bool packTextures;
         public BakedAsset bakedAsset;
 
         public SceneAsset SceneAsset => sceneAsset;
@@ -32,16 +33,20 @@ namespace Kanikama.Editor
             {
                 bakedAsset.kanikamaDirectionalMapArrays = new List<Texture2DArray>(asset.kanikamaDirectionalMapArrays);
             }
+
             if (createCustomRenderTexture)
             {
                 bakedAsset.customRenderTextures = new List<CustomRenderTexture>(asset.customRenderTextures);
                 bakedAsset.customRenderTextureMaterials = new List<Material>(asset.customRenderTextureMaterials);
             }
+
             if (createRenderTexture)
             {
                 bakedAsset.renderTextures = new List<RenderTexture>(asset.renderTextures);
                 bakedAsset.renderTextureMaterials = new List<Material>(asset.renderTextureMaterials);
             }
+
+            bakedAsset.sliceCount = asset.sliceCount;
         }
 
         public static KanikamaSettings FindOrCreateSettings(SceneAsset sceneAsset)
@@ -67,6 +72,7 @@ namespace Kanikama.Editor
                 var settings = AssetDatabase.LoadAssetAtPath<KanikamaSettings>(path);
                 if (settings.SceneAsset == sceneAsset) return settings;
             }
+
             return null;
         }
     }

--- a/Kanikama/Assets/Kanikama/Scripts/Editor/StandardShaderGUI.cs
+++ b/Kanikama/Assets/Kanikama/Scripts/Editor/StandardShaderGUI.cs
@@ -61,6 +61,7 @@ namespace Kanikama.Editor
 
             public static string kanikamaText = "Kanikama";
             public static GUIContent kanikamaModeText = EditorGUIUtility.TrTextContent("Kanikama Mode", "Kanikama Mode");
+            public static GUIContent kanikamaPackText = EditorGUIUtility.TrTextContent("RGB Packing", "RGB Packing");
         }
 
         MaterialProperty blendMode = null;
@@ -91,6 +92,7 @@ namespace Kanikama.Editor
         MaterialProperty uvSetSecondary = null;
 
         MaterialProperty kanikamaMode = null;
+        MaterialProperty kanikamaPack = null;
 
         MaterialEditor m_MaterialEditor;
         WorkflowMode m_WorkflowMode = WorkflowMode.Specular;
@@ -133,6 +135,7 @@ namespace Kanikama.Editor
             uvSetSecondary = FindProperty("_UVSec", props);
 
             kanikamaMode = FindProperty("_Kanikama_Mode", props);
+            kanikamaPack = FindProperty("_Kanikama_Pack", props);
         }
 
         public override void OnGUI(MaterialEditor materialEditor, MaterialProperty[] props)
@@ -471,6 +474,7 @@ namespace Kanikama.Editor
         void DoKanikamaArea()
         {
             m_MaterialEditor.ShaderProperty(kanikamaMode, Styles.kanikamaModeText);
+            m_MaterialEditor.ShaderProperty(kanikamaPack, Styles.kanikamaPackText);
         }
     }
 } // namespace Kanikama.Editor

--- a/Kanikama/Assets/Kanikama/Scripts/Editor/UtilityWindow.cs
+++ b/Kanikama/Assets/Kanikama/Scripts/Editor/UtilityWindow.cs
@@ -6,9 +6,13 @@ namespace Kanikama.Editor
 {
     class UtilityWindow : EditorWindow
     {
-        TextureGenerator.Parameter texParam;
+        [SerializeField] TextureGenerator.Parameter texParam;
+        [SerializeField] TextureGenerator.ImportParameter importParam;
         RenderTextureDescriptor rtDescriptor;
         Vector2 scrollPosition = new Vector2(0, 0);
+        SerializedObject serializedObject;
+        SerializedProperty texParamProperty;
+        SerializedProperty importParamProperty;
 
         [MenuItem("Window/Kanikama/Utility")]
         static void ShowWindow()
@@ -32,6 +36,9 @@ namespace Kanikama.Editor
         {
             titleContent.text = "Kanikama Utility";
             rtDescriptor = new RenderTextureDescriptor(256, 256);
+            serializedObject = new SerializedObject(this);
+            texParamProperty = serializedObject.FindProperty(nameof(texParam));
+            importParamProperty = serializedObject.FindProperty(nameof(importParam));
             Show();
         }
 
@@ -41,20 +48,13 @@ namespace Kanikama.Editor
             var indentLevel = EditorGUI.indentLevel;
             using (new EditorGUI.IndentLevelScope(indentLevel + 1))
             {
-                if (texParam is null)
-                {
-                    texParam = new TextureGenerator.Parameter();
-                }
-                texParam.width = EditorGUILayout.IntField("width", texParam.width);
-                texParam.height = EditorGUILayout.IntField("height", texParam.height);
-                texParam.format = (TextureFormat)EditorGUILayout.EnumPopup("format", texParam.format);
-                texParam.extension = (TextureGenerator.TextureExtension)EditorGUILayout.EnumPopup("ext", texParam.extension);
-                texParam.mipChain = EditorGUILayout.Toggle("mipChain", texParam.mipChain);
-                texParam.linear = EditorGUILayout.Toggle("linear", texParam.linear);
-                texParam.isReadable = EditorGUILayout.Toggle("is readable", texParam.isReadable);
+                EditorGUILayout.PropertyField(texParamProperty);
+                EditorGUILayout.PropertyField(importParamProperty);
                 if (GUILayout.Button("Create"))
                 {
-                    var tex = TextureGenerator.GenerateTexture("Assets", "texture", texParam);
+                    serializedObject.ApplyModifiedProperties();
+                    var tex = TextureGenerator.GenerateTexture(texParam);
+                    TextureGenerator.SaveTexture2D(tex, "Assets", "texture", importParam);
                     Selection.activeObject = tex;
                 }
             }

--- a/Kanikama/Assets/Kanikama/Scripts/Udon/Editor/KanikamaMapArrayProviderEditor.cs
+++ b/Kanikama/Assets/Kanikama/Scripts/Udon/Editor/KanikamaMapArrayProviderEditor.cs
@@ -81,8 +81,7 @@ namespace Kanikama.Udon.Editor
                 prop.objectReferenceValue = bakedAsset.kanikamaDirectionalMapArrays[i];
             }
 
-            var sliceCount = arrayCount > 0 ? bakedAsset.kanikamaMapArrays[0].depth : 0;
-            this.sliceCount.intValue = sliceCount;
+            sliceCount.intValue = bakedAsset.sliceCount;
 
             serializedObject.ApplyModifiedProperties();
             UdonSharpEditorUtility.CopyProxyToUdon(proxy);

--- a/Kanikama/Assets/Kanikama/Shaders/CGIncludes/KanikamaComposite.hlsl
+++ b/Kanikama/Assets/Kanikama/Shaders/CGIncludes/KanikamaComposite.hlsl
@@ -28,10 +28,21 @@ UNITY_DECLARE_TEX2DARRAY(knkm_LightmapArray);
 inline half3 KanikamaSampleLightmapArray(float2 lightmapUV)
 {
     half3 col = 0;
+#if defined(_KANIKAMA_PACK)
+    const int loopCount = ceil( (float)knkm_Count / 3.0);
+    for(int i = 0; i < loopCount; i++)
+    {
+        float3 c = DecodeLightmap(UNITY_SAMPLE_TEX2DARRAY(knkm_LightmapArray, float3(lightmapUV.x, lightmapUV.y, i)));
+        col += c.r * knkm_Colors[i * 3];
+        col += c.g * knkm_Colors[i * 3 + 1];
+        col += c.b * knkm_Colors[i * 3 + 2];
+    }
+#else
     for (int i = 0; i < knkm_Count; i++)
     {
         col += DecodeLightmap(UNITY_SAMPLE_TEX2DARRAY(knkm_LightmapArray, float3(lightmapUV.x, lightmapUV.y, i))) * knkm_Colors[i];
     }
+#endif
 
     return col;
 }
@@ -47,12 +58,30 @@ UNITY_DECLARE_TEX2DARRAY_NOSAMPLER(knkm_LightmapIndArray);
 inline half3 KanikamaSampleDirectionalLightmapArray(float2 lightmapUV, float3 normalWorld)
 {
     half3 col = 0;
+#if _KANIKAMA_PACK
+    const int loopCount = ceil((float)knkm_Count * 0.3333333);
+    for(int i = 0; i < loopCount; i++)
+    {
+        float3 c = DecodeLightmap(UNITY_SAMPLE_TEX2DARRAY(knkm_LightmapArray, float3(lightmapUV.x, lightmapUV.y, i)));
+        int i3 = i * 3;
+        for(int j = 0; j < 3 ; j++)
+        {
+            int k = i3 + j;
+            if (k >= knkm_Count)
+            {
+                break;
+            }
+            col += DecodeDirectionalLightmap(c[j] * knkm_Colors[k], UNITY_SAMPLE_TEX2DARRAY_SAMPLER(knkm_LightmapIndArray, knkm_LightmapArray, float3(lightmapUV.x, lightmapUV.y, i3 )), normalWorld);;
+        }
+    }
+#else
     for (int i = 0; i < knkm_Count; i++)
     {
         half3 bakedColor = DecodeLightmap(UNITY_SAMPLE_TEX2DARRAY(knkm_LightmapArray, float3(lightmapUV.x, lightmapUV.y, i))) * knkm_Colors[i];
         fixed4 bakedDirTex = UNITY_SAMPLE_TEX2DARRAY_SAMPLER(knkm_LightmapIndArray, knkm_LightmapArray, float3(lightmapUV.x, lightmapUV.y, i));
         col += DecodeDirectionalLightmap(bakedColor, bakedDirTex, normalWorld);
     }
+#endif
 
     return col;
 }
@@ -63,12 +92,41 @@ inline half3 KanikamaSampleDirectionalLightmapArray(float2 lightmapUV, float3 no
 
 // Directional lightmap specular based on BakeryDirectionalLightmapSpecular in Bakery.cginc by Mr F
 // https://geom.io/bakery/wiki/
-inline void KanikamaDirectionalLightmapSpecular(float2 lightmapUV, half3 normalWorld, half3 viewDir, half roughness, half occulsion, out half3 diffuse, out half3 specular)
+inline void KanikamaDirectionalLightmapSpecular(float2 lightmapUV, half3 normalWorld, half3 viewDir, half roughness,
+                                                half occulsion, out half3 diffuse, out half3 specular)
 {
+    #if _KANIKAMA_PACK
+    const int loopCount = ceil((float)knkm_Count * 0.3333333);
+    for(int i = 0; i < loopCount; i++)
+    {
+        float3 c = DecodeLightmap(UNITY_SAMPLE_TEX2DARRAY(knkm_LightmapArray, float3(lightmapUV.x, lightmapUV.y, i)));
+        int i3 = i * 3;
+        for(int j = 0; j < 3 ; j++)
+        {
+            int k = i3 + j;
+            if (k >= knkm_Count)
+            {
+                break;
+            }
+            half3 bakedColor = c[j] * knkm_Colors[k];
+            half4 dirTex = UNITY_SAMPLE_TEX2DARRAY_SAMPLER(knkm_LightmapIndArray, knkm_LightmapArray, float3(lightmapUV.x, lightmapUV.y, i3));
+            half3 dominantDir = dirTex.xyz - 0.5;
+            half3 halfDir = Unity_SafeNormalize(normalize(dominantDir) + viewDir);
+            half nh = saturate(dot(normalWorld, halfDir));
+            half spec = GGXTerm(nh, roughness);
+            half halfLambert = dot(normalWorld, dominantDir) + 0.5;
+            half3 diff = bakedColor * halfLambert / max(1e-4h, dirTex.w);
+            diffuse += diff * occulsion;
+            specular += spec * bakedColor * occulsion;
+        }
+    }
+    #else
     for (int i = 0; i < knkm_Count; i++)
     {
-        half3 bakedColor = DecodeLightmap(UNITY_SAMPLE_TEX2DARRAY(knkm_LightmapArray, float3(lightmapUV.x, lightmapUV.y, i))) * knkm_Colors[i];
-        half4 dirTex = UNITY_SAMPLE_TEX2DARRAY_SAMPLER(knkm_LightmapIndArray, knkm_LightmapArray, float3(lightmapUV.x, lightmapUV.y, i));
+        half3 bakedColor = DecodeLightmap(
+            UNITY_SAMPLE_TEX2DARRAY(knkm_LightmapArray, float3(lightmapUV.x, lightmapUV.y, i))) * knkm_Colors[i];
+        half4 dirTex = UNITY_SAMPLE_TEX2DARRAY_SAMPLER(knkm_LightmapIndArray, knkm_LightmapArray,
+                                                       float3(lightmapUV.x, lightmapUV.y, i));
         half3 dominantDir = dirTex.xyz - 0.5;
         half3 halfDir = Unity_SafeNormalize(normalize(dominantDir) + viewDir);
         half nh = saturate(dot(normalWorld, halfDir));
@@ -78,6 +136,7 @@ inline void KanikamaDirectionalLightmapSpecular(float2 lightmapUV, half3 normalW
         diffuse += diff * occulsion;
         specular += spec * bakedColor * occulsion;
     }
+    #endif
 }
 #endif // defined(_KANIKAMA_MODE_DIRECTIONAL)
 #endif // defined(_KANIKAMA_MODE_ARRAY)

--- a/Kanikama/Assets/Kanikama/Shaders/Kanikama_Pack.shader
+++ b/Kanikama/Assets/Kanikama/Shaders/Kanikama_Pack.shader
@@ -1,0 +1,60 @@
+﻿Shader "Kanikama/Pack"
+{
+    Properties
+    {
+        _Tex0("Texture 0", 2D) = "white" {}
+        _Tex1("Texture 1", 2D) = "white" {}
+        _Tex2("Texture 2", 2D) = "white" {}
+        _Tex3("Texture 3", 2D) = "white" {}
+    }
+    SubShader
+    {
+        Cull Off ZWrite Off ZTest Always
+
+        Pass
+        {
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+            };
+
+            struct v2f
+            {
+                float2 uv : TEXCOORD0;
+                float4 vertex : SV_POSITION;
+            };
+
+            v2f vert (appdata v)
+            {
+                v2f o;
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.uv = v.uv;
+                return o;
+            }
+
+            sampler2D _Tex0;
+            sampler2D _Tex1;
+            sampler2D _Tex2;
+            sampler2D _Tex3;
+
+            half4 frag(v2f i) : SV_Target
+            {
+                float2 uv = i.uv;
+                half4 col;
+                col.r = Luminance(tex2D(_Tex0, uv).rgb);
+                col.g = Luminance(tex2D(_Tex1, uv).rgb);
+                col.b = Luminance(tex2D(_Tex2, uv).rgb);
+                col.a = Luminance(tex2D(_Tex3, uv).rgb);
+                return col;
+            }
+            ENDCG
+        }
+    }
+}

--- a/Kanikama/Assets/Kanikama/Shaders/Kanikama_Pack.shader.meta
+++ b/Kanikama/Assets/Kanikama/Shaders/Kanikama_Pack.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 0c8f22b3620b1414f9d48b892bc7465d
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Kanikama/Assets/Kanikama/Shaders/Kanikama_Surface.shader
+++ b/Kanikama/Assets/Kanikama/Shaders/Kanikama_Surface.shader
@@ -3,6 +3,7 @@
     Properties
     {
         [KeywordEnum(None, Single, Array, Directional, Directional_Specular)] _Kanikama_Mode("Kanikama Mode", Float) = 0
+        [Toggle(_KANIKAMA_PACK)] _Kanikama_Pack("Enable RGB Packing", Float) = 0
 
         [Space]
         [Header(Base)]
@@ -52,6 +53,8 @@
         #pragma target 3.0
 
         #pragma shader_feature_local_fragment _ _KANIKAMA_MODE_SINGLE _KANIKAMA_MODE_ARRAY _KANIKAMA_MODE_DIRECTIONAL _KANIKAMA_MODE_DIRECTIONAL_SPECULAR
+        #pragma shader_feature_local_fragment _ _KANIKAMA_PACK
+
         #pragma shader_feature_local_fragment _ _EMISSION
         #pragma shader_feature_local_fragment _ _PARALLAX
 

--- a/Kanikama/Assets/Kanikama/Shaders/Standard/Kanikama_Standard.shader
+++ b/Kanikama/Assets/Kanikama/Shaders/Standard/Kanikama_Standard.shader
@@ -6,6 +6,7 @@ Shader "Kanikama/Standard"
     Properties
     {
         [KeywordEnum(None, Single, Array, Directional, Directional_Specular)] _Kanikama_Mode("Kanikama Mode", Float) = 0
+        [Toggle(_KANIKAMA_PACK)] _Kanikama_Pack("Enable RGB Packing", Float) = 0
         [Space]
 
         _Color("Color", Color) = (1,1,1,1)
@@ -87,6 +88,7 @@ Shader "Kanikama/Standard"
             #pragma shader_feature _PARALLAXMAP
 
             #pragma shader_feature_local_fragment _ _KANIKAMA_MODE_SINGLE _KANIKAMA_MODE_ARRAY _KANIKAMA_MODE_DIRECTIONAL _KANIKAMA_MODE_DIRECTIONAL_SPECULAR
+            #pragma shader_feature_local_fragment _ _KANIKAMA_PACK
 
             #pragma multi_compile_fwdbase
             #pragma multi_compile_fog


### PR DESCRIPTION
close https://github.com/shivaduke28/kanikama/issues/72

If **Pack Texture** is enabled in Bake Window, Kanikama will packs 3 lightmaps into single lightmap.
For converting `float3` to `float`, we use Built-in `Luminance` function.

![pack1](https://user-images.githubusercontent.com/45098240/169631374-14d73558-6504-4e25-949a-fb685fe8336d.png)

![pack2](https://user-images.githubusercontent.com/45098240/169631372-e946e4da-4b23-4086-ae0a-41f03a6d4133.png)

