### PR TITLE
Fix BakeryMonitorGridRenderer prefab again

### DIFF
--- a/Kanikama/Assets/Kanikama/Prefabs/Bakery/BakeryMonitorGridRenderer.prefab
+++ b/Kanikama/Assets/Kanikama/Prefabs/Bakery/BakeryMonitorGridRenderer.prefab
@@ -50,7 +50,7 @@ MeshRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8980632914921211951}
   m_Enabled: 1
-  m_CastShadows: 0
+  m_CastShadows: 1
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
   m_MotionVectors: 1
@@ -99,9 +99,9 @@ MonoBehaviour:
   texture: {fileID: 0}
   cutoff: 100
   samples: 256
-  samples2: 0
+  samples2: 16
   bitmask: 1
-  selfShadow: 0
+  selfShadow: 1
   bakeToIndirect: 1
   shadowmask: 0
   indirectIntensity: 1

--- a/Kanikama/Assets/Kanikama/Scripts/Runtime/Components/Bakery/KanikamaBakeryGridRenderer.cs
+++ b/Kanikama/Assets/Kanikama/Scripts/Runtime/Components/Bakery/KanikamaBakeryGridRenderer.cs
@@ -32,6 +32,7 @@ namespace Kanikama.Bakery
 
         public override void OnBake()
         {
+            gameObject.tag = "Untagged";
             renderer.enabled = true;
             bakeryLightMesh.enabled = true;
         }
@@ -42,6 +43,7 @@ namespace Kanikama.Bakery
 
         public override void Rollback()
         {
+            gameObject.tag = "EditorOnly";
             renderer.enabled = false;
             bakeryLightMesh.enabled = true;
         }


### PR DESCRIPTION
@guycalledfrank told me to fix the issue in a correct way:

- enable Cast Shadow in MeshRenderer attached to BakeryLightMesh
- remove `EditorOnly` tag on baking