### PR TITLE
Disable "autoReferenced" for kanikama asmdefs.

### DIFF
--- a/Kanikama/Packages/net.shivaduke28.kanikama.bakery/Editor/Application/Kanikama.Bakery.Editor.Application.asmdef
+++ b/Kanikama/Packages/net.shivaduke28.kanikama.bakery/Editor/Application/Kanikama.Bakery.Editor.Application.asmdef
@@ -16,7 +16,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [
         "BAKERY_INCLUDED"
     ],

--- a/Kanikama/Packages/net.shivaduke28.kanikama.bakery/Editor/Baking/Kanikama.Bakery.Editor.Baking.asmdef
+++ b/Kanikama/Packages/net.shivaduke28.kanikama.bakery/Editor/Baking/Kanikama.Bakery.Editor.Baking.asmdef
@@ -1,25 +1,25 @@
 {
-  "name": "Kanikama.Bakery.Editor.Baking",
-  "references": [
-    "BakeryRuntimeAssembly",
-    "BakeryEditorAssembly",
-    "Kanikama.Application",
-    "Kanikama.Editor.Application",
-    "Kanikama.Baking",
-    "Kanikama.Bakery.Baking",
-    "Kanikama.Editor.Baking"
-  ],
-  "includePlatforms": [
-    "Editor"
-  ],
-  "excludePlatforms": [],
-  "allowUnsafeCode": false,
-  "overrideReferences": false,
-  "precompiledReferences": [],
-  "autoReferenced": true,
-  "defineConstraints": [
-    "BAKERY_INCLUDED"
-  ],
-  "versionDefines": [],
-  "noEngineReferences": false
+    "name": "Kanikama.Bakery.Editor.Baking",
+    "references": [
+        "BakeryRuntimeAssembly",
+        "BakeryEditorAssembly",
+        "Kanikama.Application",
+        "Kanikama.Editor.Application",
+        "Kanikama.Baking",
+        "Kanikama.Bakery.Baking",
+        "Kanikama.Editor.Baking"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "BAKERY_INCLUDED"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/Kanikama/Packages/net.shivaduke28.kanikama.udon/Editor/Bakery/Kanikama.GI.Udon.Editor.Bakery.asmdef
+++ b/Kanikama/Packages/net.shivaduke28.kanikama.udon/Editor/Bakery/Kanikama.GI.Udon.Editor.Bakery.asmdef
@@ -1,27 +1,27 @@
 {
-  "name": "Kanikama.GI.Udon.Editor.Bakery",
-  "references": [
-    "Kanikama.Application",
-    "Kanikama.Baking",
-    "Kanikama.Editor.Application",
-    "Kanikama.Editor.Baking",
-    "Kanikama.Udon",
-    "Kanikama.Bakery.Baking",
-    "Kanikama.Bakery.Editor.Baking",
-    "UdonSharp.Runtime",
-    "UdonSharp.Editor"
-  ],
-  "includePlatforms": [
-    "Editor"
-  ],
-  "excludePlatforms": [],
-  "allowUnsafeCode": false,
-  "overrideReferences": false,
-  "precompiledReferences": [],
-  "autoReferenced": true,
-  "defineConstraints": [
-    "BAKERY_INCLUDED"
-  ],
-  "versionDefines": [],
-  "noEngineReferences": false
+    "name": "Kanikama.GI.Udon.Editor.Bakery",
+    "references": [
+        "Kanikama.Application",
+        "Kanikama.Baking",
+        "Kanikama.Editor.Application",
+        "Kanikama.Editor.Baking",
+        "Kanikama.Udon",
+        "Kanikama.Bakery.Baking",
+        "Kanikama.Bakery.Editor.Baking",
+        "UdonSharp.Runtime",
+        "UdonSharp.Editor"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "BAKERY_INCLUDED"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
 }


### PR DESCRIPTION
This will fix some compile errors when UdonSharpVideo is used with Kanikama, reported by https://twitter.com/koiwaiyomogi/status/1688096757048299521.

Thank you for reporting that issue <3