### PR TITLE
Fix bakery lightmaps can not be collected when directional mode is not MonoSH

### DIFF
--- a/Kanikama/Packages/net.shivaduke28.kanikama.bakery/Editor/Baking/KanikamaBakeryUtility.cs
+++ b/Kanikama/Packages/net.shivaduke28.kanikama.bakery/Editor/Baking/KanikamaBakeryUtility.cs
@@ -62,10 +62,6 @@ namespace Kanikama.Bakery.Editor.Baking
                         return false;
                     }
                 }
-                else
-                {
-                    return false;
-                }
             }
 
             if (Color.IsMatch(name))


### PR DESCRIPTION
close https://github.com/shivaduke28/kanikama/issues/226